### PR TITLE
[System.Core] ReaderWriterLockSlim.cs now builds with mono.

### DIFF
--- a/System.Core/System/threading/ReaderWriterLockSlim/ReaderWriterLockSlim.cs
+++ b/System.Core/System/threading/ReaderWriterLockSlim/ReaderWriterLockSlim.cs
@@ -155,7 +155,9 @@ namespace System.Threading
             lockID = Interlocked.Increment(ref s_nextLockID);
         }
 
+#if NET_4_5
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
+#endif
         private static bool IsRWEntryEmpty(ReaderWriterCount rwc)
         {
             if (rwc.lockID == 0)
@@ -179,7 +181,9 @@ namespace System.Threading
         /// entry for this thread, but doesn't want to add one if an existing one
         /// could not be found.
         /// </summary>
+#if NET_4_5
 		[MethodImpl(MethodImplOptions.AggressiveInlining)]
+#endif
         private ReaderWriterCount GetThreadRWCount(bool dontAllocate)
         {
 			ReaderWriterCount rwc = t_rwc;
@@ -1113,7 +1117,9 @@ namespace System.Threading
             return owners & READER_MASK;
         }
 
+#if NET_4_5
 		[MethodImpl(MethodImplOptions.AggressiveInlining)]
+#endif
         private void EnterMyLock()
         {
             if (Interlocked.CompareExchange(ref myLock, 1, 0) != 0)
@@ -1146,7 +1152,11 @@ namespace System.Threading
         private void ExitMyLock()
         {
             Debug.Assert(myLock != 0, "Exiting spin lock that is not held");
+#if NET_4_5
             Volatile.Write(ref myLock, 0);
+#else
+            Thread.VolatileWrite(ref myLock, 0);
+#endif
         }
 
 #if DEBUG


### PR DESCRIPTION
- Builds without [MethodImpl(MethodImplOptions.AggressiveInlining)]
  when target framework version is lower than 4.5.
- Use Thread.Volatile instead of Volatile.Read when target framework
  version is lower than 4.5.

Required by mono/mono#1436
