### PR TITLE
[System] Fix System.Timers.Timer regression on ARM

### DIFF
--- a/System/services/timers/system/timers/Timer.cs
+++ b/System/services/timers/system/timers/Timer.cs
@@ -62,12 +62,7 @@ namespace System.Timers {
             if (interval <= 0)
                 throw new ArgumentException(SR.GetString(SR.InvalidParameter, "interval", interval));
                         
-            double roundedInterval = Math.Ceiling(interval);
-            if (roundedInterval > Int32.MaxValue || roundedInterval <= 0) {
-                throw new ArgumentException(SR.GetString(SR.InvalidParameter, "interval", interval));                
-            }
-
-            this.interval = (int) roundedInterval;
+            this.interval = CalculateRoundedInterval(interval);
         }
 
         /// <devdoc>
@@ -128,7 +123,7 @@ namespace System.Timers {
                                 throw new ObjectDisposedException(GetType().Name);
                             }
 
-                            int i = (int)Math.Ceiling(interval);
+                            int i = CalculateRoundedInterval(interval);
                             cookie = new Object();
                             timer = new System.Threading.Timer(callback, cookie, i, autoReset? i:Timeout.Infinite);
                         }
@@ -141,9 +136,16 @@ namespace System.Timers {
           }
         }
 
+        private static int CalculateRoundedInterval(double interval) {
+            double roundedInterval = Math.Ceiling(interval);
+            if (roundedInterval > Int32.MaxValue || roundedInterval <= 0) {
+                throw new ArgumentException(SR.GetString(SR.InvalidParameter, "interval", interval));
+            }
+            return (int)roundedInterval;
+        }
 
         private void UpdateTimer() {
-            int i = (int)Math.Ceiling(interval);
+            int i = CalculateRoundedInterval(interval);
             timer.Change(i, autoReset? i :Timeout.Infinite );
         }
         


### PR DESCRIPTION
When setting `Interval = double.MaxValue` like in the `TimerTest.Interval_TooHigh_ThrowOnEnabled` and `TimerTest.Interval_TooHigh_Enabled_Throw` Mono unit tests there was a regression on ARM in that the `ArgumentOutOfRangeException` wasn't thrown as expected.

Turns out, on ARM the call to `(int)Math.Ceiling(double.MaxValue)` as used in `UpdateTimer()` and `Enabled` setter doesn't produce -2147483648 (i.e. `Int32.MinValue`) like on x86/amd64 but rather 2147483647 (i.e. `Int32.MaxValue`), which is perfectly valid as the cast overflows and the result is an undefined value.
This means that the value passed to the underlying `System.Threading.Timer` is not negative and no `ArgumentOutOfRangeException` is thrown there.

The fix is to properly check for `interval>Int32.MaxValue` like is done already in the constructor.
I pulled that logic out and introduced a separate method `CalculateRoundedInterval()`.

Note: The thrown exception changes from an `ArgumentOutOfRangeException` inside of `System.Threading.Timer` to an `ArgumentException` inside of `CalculateRoundedInterval()`.
I think this has minimal impact as no-one should rely on this exception anyway and it actually matches what [MSDN docs](https://msdn.microsoft.com/en-us/library/system.timers.timer.interval(v=vs.110).aspx) say should happen in this case (even though the MS.NET 4.5 implementation doesn't comply).
Mono's implementation also did the same [before the referencesource code](https://github.com/mono/mono/blob/4cb3f77b4bbf703b1cda59db2f5aee206e35d31a/mcs/class/System/System.Timers/Timer.cs#L95-L96).