### PR TITLE
[corlib] Fix DateTime regression on ARM

### DIFF
--- a/mscorlib/system/datetime.cs
+++ b/mscorlib/system/datetime.cs
@@ -348,7 +348,11 @@ namespace System {
         // Returns the DateTime resulting from adding a fractional number of
         // time units to this DateTime.
         private DateTime Add(double value, int scale) {
-            long millis = (long)(value * scale + (value >= 0? 0.5: -0.5));
+            double temp = (value * scale + (value >= 0? 0.5: -0.5));
+            if (temp < long.MinValue || temp > long.MaxValue)
+                throw new ArgumentOutOfRangeException("value", Environment.GetResourceString("ArgumentOutOfRange_AddValue"));
+
+            long millis = (long)temp;
             if (millis <= -MaxMillis || millis >= MaxMillis) 
                 throw new ArgumentOutOfRangeException("value", Environment.GetResourceString("ArgumentOutOfRange_AddValue"));
             return AddTicks(millis * TicksPerMillisecond);


### PR DESCRIPTION
This is the same issue as in https://github.com/mono/referencesource/pull/7, i.e. there's an overflow when casting a too large value from double->long and the referencesource implementation relies on this being a large negative value in order for the ArgumentOutOfRangeException to be properly thrown.

As Mono's runtime on ARM in this case returns -1, the exception isn't thrown.

The fix is to introduce an explicit check for the value fitting into long.
It fixes a couple of DateTime unit tests that currently fail on ARM.

I raised this upstream at https://github.com/dotnet/corefx/issues/1115 and while they agree it isn't the ideal behavior they're not gonna change it for compat reasons (even though all of the MS.NET platforms I checked on aren't affected as they all return a large negative value).

/cc @marek-safar 