### PR TITLE
Ifdefed out some methods from methodbody.cs and methodbuilder.cs

### DIFF
--- a/mscorlib/system/reflection/emit/methodbuilder.cs
+++ b/mscorlib/system/reflection/emit/methodbuilder.cs
@@ -19,7 +19,7 @@ namespace System.Reflection.Emit
     using System.Security.Permissions;
     using System.Runtime.InteropServices;
     using System.Diagnostics.Contracts;
-
+#if !MONO
     [HostProtection(MayLeakOnAbort = true)]
     [ClassInterface(ClassInterfaceType.None)]
     [ComDefaultInterface(typeof(_MethodBuilder))]
@@ -1394,6 +1394,7 @@ namespace System.Reflection.Emit
 
         #endregion
     }
+#endif
 
     /// <summary>
     /// Describes exception handler in a method body.

--- a/mscorlib/system/reflection/methodbody.cs
+++ b/mscorlib/system/reflection/methodbody.cs
@@ -22,7 +22,7 @@ namespace System.Reflection
         Finally = 0x2,
         Fault = 0x4,
     }
-    
+#if !MONO
     [System.Runtime.InteropServices.ComVisible(true)]
     public class ExceptionHandlingClause
     {
@@ -167,5 +167,6 @@ namespace System.Reflection
         public virtual int LocalIndex { get { return m_localIndex; } }
         #endregion
     }
+#endif
 }
 


### PR DESCRIPTION
Mono now uses ExceptionHandlingClauseOptions from methodbody.cs and ExceptionHandler from methobuilder.cs.
Remaining types from thoses files were ignored with ifdef.