### PR TITLE
Add BE support for Doubles

### DIFF
--- a/mscorlib/system/globalization/charunicodeinfo.cs
+++ b/mscorlib/system/globalization/charunicodeinfo.cs
@@ -157,6 +157,22 @@ namespace System.Globalization {
                 return(value);
         }
 
+        unsafe private static double EndianSwap(double value)
+        {
+            if (!BitConverter.IsLittleEndian) {
+                byte *ptr = (byte *) &value;
+                double res;
+                byte *buf = (byte *) &res;
+                ushort t = sizeof(double) - 1;
+
+                for (ushort i = 0; i < sizeof(double); i++)
+                    buf[t-i] = ptr[i];
+
+                return(res);
+            } else
+                return(value);
+        }
+
 
         //We need to allocate the underlying table that provides us with the information that we
         //use.  We allocate this once in the class initializer and then we don't need to worry
@@ -322,7 +338,7 @@ namespace System.Globalization {
             }
             return (((double*)s_pNumericValues)[pBytePtr[(ch & 0x000f)]]);
 #else
-            return (((double*)s_pNumericValues)[pBytePtr[(ch & 0x000f)]]);
+            return EndianSwap(((double*)s_pNumericValues)[pBytePtr[(ch & 0x000f)]]);
 #endif
         }
 


### PR DESCRIPTION
Missed from 41a6d3d6a5432b964b6f8439b6375ffad6f2e6cb

Author explicitly disclaims copyright ownership of change, as per https://lists.debian.org/debian-powerpc/2015/09/msg00002.html