### PR TITLE
fixing display of asmx help page (#37137)

### DIFF
--- a/System.Web.Services/System/Web/Services/Configuration/WsdlHelpGeneratorElement.cs
+++ b/System.Web.Services/System/Web/Services/Configuration/WsdlHelpGeneratorElement.cs
@@ -75,6 +75,7 @@ namespace System.Web.Services.Configuration
 			try {
 				var hack = this.EvaluationContext;
 			} catch (ConfigurationErrorsException) {
+				this.actualPath = GetConfigurationDirectory();
 				return;
 			}
 #endif
@@ -127,6 +128,7 @@ namespace System.Web.Services.Configuration
 				var hack = this.EvaluationContext;
 			} catch (ConfigurationErrorsException) {
 				base.Reset(parentElement);
+				this.actualPath = GetConfigurationDirectory();
 				return;
 			}
 #endif


### PR DESCRIPTION
if MONO_BROKEN_CONFIGURATION_DLL is defined, make sure that actualPath always gets set