### PR TITLE
[Cycle 6][System.Web.Services] Unix paths fix

### DIFF
--- a/System.Web.Services/System/Web/Services/Discovery/DiscoveryClientProtocol.cs
+++ b/System.Web.Services/System/Web/Services/Discovery/DiscoveryClientProtocol.cs
@@ -453,15 +453,15 @@ namespace System.Web.Services.Discovery {
             while (currentDir.Length > 0) {
                 if (currentDir.Length <= fullPath.Length && string.Compare(currentDir, fullPath.Substring(0, currentDir.Length), StringComparison.OrdinalIgnoreCase) == 0) {
                     answer += fullPath.Substring(currentDir.Length);
-                    if (answer.StartsWith("\\", StringComparison.Ordinal))
+                    if (answer.StartsWith(""+Path.DirectorySeparatorChar, StringComparison.Ordinal))
                         answer = answer.Substring(1);
                     return answer;
                 }
-                answer += "..\\";
+                answer += ".." + Path.DirectorySeparatorChar;
                 if (currentDir.Length < 2)
                     break;
                 else {
-                    int lastSlash = currentDir.LastIndexOf('\\', currentDir.Length - 2);
+                    int lastSlash = currentDir.LastIndexOf(Path.DirectorySeparatorChar, currentDir.Length - 2);
                     currentDir = currentDir.Substring(0, lastSlash + 1);
                 }
             }


### PR DESCRIPTION
DiscoveryClientProtocol.GetRelativePath was harcoded to use '\'.

Fixes #36116

This pull request is done from another branch within this repo so s can be more easily tested. As per @alexischr in https://github.com/mono/referencesource/pull/21.
